### PR TITLE
[add]候補からルートを選択して取得するAPIの実装

### DIFF
--- a/backend/app/route_finder.py
+++ b/backend/app/route_finder.py
@@ -24,7 +24,8 @@ def find_loop(G, orig_node, target_distance_km, node_score, lambda_score, N=2):
     best_path = None
     best_diff = float('inf')
     nodes = filter_far_nodes(G, orig_node, min_distance_m=target_distance_km * 25)
-    for _ in range(10):
+    route_suggestions = []
+    for _ in range(500): # 500回試行
         mid_nodes = [node for node in random.sample(nodes, N)]
 
         try:
@@ -38,11 +39,17 @@ def find_loop(G, orig_node, target_distance_km, node_score, lambda_score, N=2):
             total_km = total_length / 1000.0
 
             diff = abs(total_km - target_distance_km)
-            if diff < best_diff:
-                best_path = path
-                best_diff = diff
-                best_km = total_km
-                best_mid_nodes = mid_nodes            
+            if diff < target_distance_km * 0.1: # 10% の誤差を許容
+                path_positions = [(G.nodes[n]['y'], G.nodes[n]['x']) for n in path]
+                result = {
+                    'path': path,
+                    'path_positions': path_positions,
+                    'total_km': round(total_km, 3),
+                    'diff': round(diff, 3),
+                    'mid_nodes': mid_nodes
+                }
+                route_suggestions.append(result)
+                route_suggestions.sort(key=lambda x: x['diff'])
         except:
             continue
-    return best_path, best_km, best_mid_nodes
+    return route_suggestions[:5] if len(route_suggestions) > 5 else route_suggestions

--- a/backend/test-generate-route.ps1
+++ b/backend/test-generate-route.ps1
@@ -1,17 +1,9 @@
-# debug.ps1
-$env:FLASK_APP = "app/api.py"
-$env:FLASK_ENV = "development"
-
-Start-Process powershell -ArgumentList "flask run"
-
-Start-Sleep -Seconds 2
-
 $body = @{
     lat = 36.6431
     lon = 138.1887
-    distance_km = 5.0
-    lambda_score = 0.5
-    theme = "safety"
+    distance = 1.0
+    lambda_score = 0.1
+    theme = @("safety")
 } | ConvertTo-Json -Depth 3
 
 $response = Invoke-RestMethod -Method Post `

--- a/backend/test-select-route.ps1
+++ b/backend/test-select-route.ps1
@@ -1,0 +1,6 @@
+$routeIndex = 2
+$url = "http://localhost:5000/select-route/$routeIndex"
+
+$response = Invoke-WebRequest -Uri $url -Method GET -UseBasicParsing -ErrorAction Stop
+Write-Output $response.Content
+


### PR DESCRIPTION
## 内容
- `GET /select-route/<route_index>`APIの実装
- `find-loop`の内容を一部変更（試行回数の変更，ルートの選択条件の変更，ルート候補をリスト型で保存し返却する処理の追加）
- `POST /generate-route`のレスポンスに`num_paths`プロパティを追加．（生成されたルート候補の数）

## 使い方
- `GET /select-route/<route_index>`の`<route_index>`に整数値をurlのパラメータとして指定．
- バックエンド側でルート候補リストから指定されたindexの要素を取得．
- jsonレスポンス`{"path","mid_nodes","distance"}`を返す．