### PR TITLE
[add]ルート生成における中間ノードの角度的な評価の追加

### DIFF
--- a/backend/app/route_finder.py
+++ b/backend/app/route_finder.py
@@ -1,6 +1,8 @@
 import networkx as nx
 import random
 from geopy.distance import geodesic
+from itertools import combinations
+import math
 
 def custom_weight_builder(node_score, lambda_score):
     def custom_weight(u, v, data):
@@ -19,6 +21,31 @@ def filter_far_nodes(G, orig_node, min_distance_m=400):
             far_nodes.append(node)
     return far_nodes
 
+def angle_between_nodes(node1, node2, origin):
+    # node = (lat, lon)
+    vec1 = (node1[0] - origin[0], node1[1] - origin[1])
+    vec2 = (node2[0] - origin[0], node2[1] - origin[1])
+
+    # 内積とノルム
+    dot = vec1[0]*vec2[0] + vec1[1]*vec2[1]
+    norm1 = math.hypot(*vec1)
+    norm2 = math.hypot(*vec2)
+    
+    # コサインから角度を算出（0〜180度）
+    cos_theta = dot / (norm1 * norm2 + 1e-8)
+    cos_theta = max(-1.0, min(1.0, cos_theta))  # 安全性のためクランプ
+    angle_rad = math.acos(cos_theta)
+    return math.degrees(angle_rad)
+
+def average_angle_diversity(G,mid_nodes, origin):
+    angles = []
+    for n1, n2 in combinations(mid_nodes, 2):
+        node1 = (G.nodes[n1]['y'], G.nodes[n1]['x'])
+        node2 = (G.nodes[n2]['y'], G.nodes[n2]['x'])
+        angle = angle_between_nodes(node1, node2, origin)
+        angles.append(angle)
+    return sum(angles) / len(angles) if angles else 0
+
 def find_loop(G, orig_node, target_distance_km, node_score, lambda_score, N=2):
     custom_weight = custom_weight_builder(node_score, lambda_score)
     best_path = None
@@ -27,29 +54,32 @@ def find_loop(G, orig_node, target_distance_km, node_score, lambda_score, N=2):
     route_suggestions = []
     for _ in range(500): # 500回試行
         mid_nodes = [node for node in random.sample(nodes, N)]
-
+        angle = average_angle_diversity(G, mid_nodes, (G.nodes[orig_node]['y'], G.nodes[orig_node]['x']))
+        angle_penalty = max(0, 60 - angle) 
         try:
             route_nodes = [orig_node] + mid_nodes + [orig_node]
             path = []
             for u, v in zip(route_nodes[:-1], route_nodes[1:]):
                 segment = nx.astar_path(G, u, v, weight=custom_weight)
                 path += segment if not path else segment[1:]
+            path_positions = [(G.nodes[n]['y'], G.nodes[n]['x']) for n in path]
 
             total_length = sum([G.get_edge_data(u, v)[0]['length'] for u, v in zip(path[:-1], path[1:])])
             total_km = total_length / 1000.0
 
             diff = abs(total_km - target_distance_km)
-            if diff < target_distance_km * 0.1: # 10% の誤差を許容
-                path_positions = [(G.nodes[n]['y'], G.nodes[n]['x']) for n in path]
-                result = {
-                    'path': path,
-                    'path_positions': path_positions,
-                    'total_km': round(total_km, 3),
-                    'diff': round(diff, 3),
-                    'mid_nodes': mid_nodes
-                }
-                route_suggestions.append(result)
-                route_suggestions.sort(key=lambda x: x['diff'])
+            score = diff + 0.5 * angle_penalty
+            result = {
+                'path': path,
+                'path_positions': path_positions,
+                'total_km': round(total_km, 3),
+                'diff': round(diff, 3),
+                'mid_nodes': mid_nodes,
+                'angle': round(angle, 3),
+                'score': round(score, 3)
+            }
+            route_suggestions.append(result)
+            route_suggestions.sort(key=lambda x: x['score']) # 小さいほどいい
         except:
             continue
     return route_suggestions[:5] if len(route_suggestions) > 5 else route_suggestions


### PR DESCRIPTION
## 問題
- 周回ルートを生成する際，ランダムにとる中間ノードが似た方向にあると，往路と復路で経路が重複する問題があった．
- 選択されたノードと始点の角度を計算し，経路の多様性（角度の大きさ）を定量的に評価し，解決を試みた．

## 内容
- 2つの中間ノードを始点で結んだ時の角度（0~180度）を計算する関数（`angle_between_nodes()`）の追加
- 2つ以上の場合に拡張し，平均角度を計算する関数（`average_angle_diversity()`）の追加．内部で`angle_between_nodes()`を逐次実行．
- 角度の小ささに応じてペナルティを与え，閾値（今回は60度）を超えた場合はペナルティなしとし，目的距離の誤差と角度のペナルティを統合したスコアで経路を評価する．スコアは小さいほどいい．