### PR TITLE
[add]ルートの詳細化，複数テーマ選択機能の追加

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -2,7 +2,12 @@ from flask import Flask, request, Response, jsonify
 from flask_cors import CORS
 from .route_service import generate_routes
 from typing import Tuple, List, Dict, Any, Union
-import networkx as nx
+import logging
+
+logging.basicConfig(
+    level = logging.INFO,
+    format = '[%(asctime)s] %(levelname)s in %(module)s: %(message)s'
+)
 
 app = Flask(__name__)
 CORS(app, supports_credentials=True)
@@ -22,6 +27,7 @@ def build_response(suggested_routes: List[Dict[str,Any]]) -> Union[Response, Tup
         return jsonify({"error": "ルートが見つかりませんでした"}), 404
     
     best_route = suggested_routes[0]
+    print(best_route)
     return jsonify({
         "path": best_route['path_positions'],
         "num_paths": len(suggested_routes),
@@ -32,6 +38,7 @@ def build_response(suggested_routes: List[Dict[str,Any]]) -> Union[Response, Tup
 app.suggested_routes = []
 @app.route('/generate-route', methods=['POST'])
 def generate_route():
+    logging.info("ルート生成リクエストを受け取りました")
     data = request.json
     lat, lon, distance_km, lambda_score, theme = parse_request(data)
     app.suggested_routes = generate_routes(lat, lon, distance_km, lambda_score, theme)

--- a/backend/app/route_service.py
+++ b/backend/app/route_service.py
@@ -1,14 +1,15 @@
 from .graph_builder import get_walk_graph, get_origin_node
-from .score_builder import build_node_score_map
+from .score_builder import get_tag_score, build_node_score_map
 from .route_finder import find_loop
-from .tag_presets import preset_map
 from typing import Any, Dict, List
+import logging
 
 def generate_routes(lat: float, lon: float, distance_km: float, lambda_score: float, theme: List[str])-> List[Dict[str, Any]]:
     graph_dist = distance_km * 0.5 * 1000  # 目的距離/2[m]四方のグラフを生成
     G = get_walk_graph(lat, lon, graph_dist)
     orig_node = get_origin_node(G, lat, lon)
-    tag_score_list = preset_map.get(theme[n] for n in theme)
+    tag_score_list = get_tag_score(theme)
+    logging.info(f"これらのtagでルートを評価します　ー＞　{tag_score_list}")
     node_score = build_node_score_map(G, (lat, lon), tag_score_list, dist=graph_dist)
     
     suggested_routes = find_loop(G, orig_node, distance_km, node_score, lambda_score)

--- a/backend/app/score_builder.py
+++ b/backend/app/score_builder.py
@@ -1,21 +1,39 @@
 import osmnx as ox
 import networkx as nx
-from typing import Tuple, Dict, List
+from .tag_presets import preset_map
+import logging
+from typing import Tuple, Dict, List,Any
+from collections import defaultdict
 
-def build_node_score_map(G: nx.Graph, center_point: Tuple[float, float], tag_score_list: List[Dict], dist: float=2000) -> Dict[int, int]:
+def get_tag_score(theme):
+    return [ts for t in theme for ts in preset_map.get(t, [])]
+
+def merge_tags_for_overpass(tag_score_list: List[Tuple[Dict[str, Any], int]]) -> Dict[str, Any]:
+    tag_map = defaultdict(set)
+    for tags, _ in tag_score_list:
+        for key, value in tags.items():
+            tag_map[key].add(value)
+
+    # Overpass API は list[str] も受け取れる
+    return {k: list(vs) if len(vs) > 1 else list(vs)[0] for k, vs in tag_map.items()}
+
+def build_node_score_map(G: nx.Graph, center_point: Tuple[float, float], tag_score_list: List[Tuple[Dict,int]], dist: float=2000) -> Dict[int, int]:
     node_score = {}
     if not tag_score_list:
-        print("タグスコアリストが空です。")
+        logging.warning(f"tag_score_listが空です{tag_score_list}")
         return node_score
-    for tags, score in tag_score_list:
+    unique_tags = merge_tags_for_overpass(tag_score_list)
+    try:
+        gdf = ox.features.features_from_point(center_point, tags=unique_tags, dist=dist)
+    except Exception as e:
+        logging.error(f"Overpass APIからの取得に失敗: {e}")
+        return node_score
+    for _, row in gdf.iterrows():
         try:
-            gdf = ox.features.features_from_point(center_point, tags=tags, dist=dist)
-            for _, row in gdf.iterrows():
-                try:
-                    node = ox.distance.nearest_nodes(G, row.geometry.x, row.geometry.y)
-                    node_score[node] = node_score.get(node, 0) + score
-                except:
-                    continue
+            node = ox.distance.nearest_nodes(G, row.geometry.x, row.geometry.y)
         except Exception as e:
-            print(f"タグ {tags} の取得に失敗: {e}")
+            continue
+        for tags, score in tag_score_list:
+            if all(row.get(k) == v for k, v in tags.items()):
+                node_score[node] = node_score.get(node, 0) + score
     return node_score

--- a/backend/app/visualizer.py
+++ b/backend/app/visualizer.py
@@ -1,37 +1,32 @@
-import matplotlib.pyplot as plt
 import osmnx as ox
+import matplotlib.pyplot as plt
+import networkx as nx
+from typing import List
 
-def visualize_midpoints(G, orig_node, mid_nodes, full_path=None, gdf=None, gdf_color='purple', gdf_label='POI'):
-    node_colors = ['#cccccc'] * len(G.nodes)
-    node_sizes = [1] * len(G.nodes)
+def plot_path_on_graph(G: nx.Graph, path: List[int], show: bool = True, save_path: str = None) -> None:
+    """
+    与えられたノードIDのpathに基づいてグラフ上にルートを描画します。
+    
+    Parameters:
+        G (nx.Graph): OSMnxで生成されたグラフ
+        path (List[int]): ノードIDの順列（ルート）
+        show (bool): その場で表示するか（True）または保存のみ（False）
+        save_path (str): 画像ファイルとして保存したい場合のパス（例: "route.png"）
+    """
+    fig, ax = ox.plot_graph_route(
+        G,
+        route=path,
+        route_color='green',
+        route_linewidth=3,
+        node_size=0,
+        show=False,
+        close=False,
+        bgcolor='white'
+    )
 
-    node_id_list = list(G.nodes)
-    node_idx = {node_id: i for i, node_id in enumerate(node_id_list)}
-
-    for mid in mid_nodes:
-        if mid in node_idx:
-            idx = node_idx[mid]
-            node_colors[idx] = 'red'
-            node_sizes[idx] = 50
-
-    if orig_node in node_idx:
-        idx = node_idx[orig_node]
-        node_colors[idx] = 'blue'
-        node_sizes[idx] = 80
-
-    fig, ax = ox.plot_graph(G,
-                            node_color=node_colors,
-                            node_size=node_sizes,
-                            edge_color='#999999',
-                            bgcolor='white',
-                            show=False,
-                            close=False)
-
-    if full_path:
-        ox.plot_graph_route(G, full_path, route_color='green', route_linewidth=3, ax=ax, show=False, close=False)
-
-    if gdf is not None and not gdf.empty:
-        gdf.plot(ax=ax, color=gdf_color, markersize=20, label=gdf_label)
-
-    plt.legend()
-    plt.show()
+    if save_path:
+        fig.savefig(save_path, bbox_inches='tight')
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)


### PR DESCRIPTION
## 内容
- ノード間の直線距離を描画する問題を解決した
- エッジの`geometry`で詳細化
- リストでテーマを受け取ると，各テーマのtagとスコアを統合して一つのリストを返す処理を追加
- 内部でAPI通信を行う関数が繰り返し呼ばれていたところを，一回の呼び出しで解決できるように変更した．