### PR TITLE
[feat]ルート選択ボタンの追加

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -23,10 +23,7 @@ def build_response(suggested_routes: List[Dict[str,Any]]) -> Union[Response, Tup
     
     best_route = suggested_routes[0]
     return jsonify({
-        "path": best_route['path_positions'],
         "num_paths": len(suggested_routes),
-        "mid_nodes": best_route['mid_nodes'],
-        "distance": best_route['total_km']
     })
 
 app.suggested_routes = []

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -121,7 +121,7 @@ const Home: React.FC = () => {
                         value={dist}
                         onChange={e => setDist(e.target.value)}
                         className="rounded-xl border-2 border-green-200 px-4 py-2 text-lg focus:ring-2 focus:ring-green-400 focus:border-green-400 outline-none transition"
-                        placeholder="例: 3"
+                        placeholder="例: 2.5"
                     />
                 </label>
                 <div className="flex flex-col gap-2">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -76,7 +76,7 @@ const Home: React.FC = () => {
             setGeoError('現在地の取得が完了するまでお待ちください');
             return;
         }
-        setIsLoading(true);  // ←追加（API開始時）
+        setIsLoading(true);
         try {
             const response = await fetch(`${API_BASE}/generate-route`, {
                 method: 'POST',
@@ -91,9 +91,10 @@ const Home: React.FC = () => {
                     theme: selected,
                 }),
             });
-            const data = await response.json();
+            if (!response.ok) throw new Error('Network error');
+            const numRoutes = await response.json();
             navigate("/map", {
-                state: { routeData: data }
+                state: { numRoutes }
             });
         } finally {
             setIsLoading(false); // MapView遷移でほぼ無効だが、失敗時にHome復帰したときのため

--- a/frontend/src/pages/MapView.tsx
+++ b/frontend/src/pages/MapView.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
+import React, { useState, useEffect, useCallback } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, Polyline, useMap } from 'react-leaflet';
 import { useLocation } from 'react-router-dom';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -25,52 +25,117 @@ const defaultIcon = L.icon({
 
 const API_BASE = import.meta.env.VITE_API_BASE;
 
+// 中心を動的に変更するための再利用可能な宣言的コンポーネント
+const ChangeMapCenter: React.FC<{ center: [number, number] }> = ({ center }) => {
+    const map = useMap();
+    useEffect(() => {
+        map.setView(center);
+    }, [center, map]);
+    return null;
+};
+
 const MapView: React.FC = () => {
     const location = useLocation();
     const numRoutes = location.state?.numRoutes?.num_paths ?? 0;
 
-    const centerPosition: [number, number] = [36.6486, 138.1948];
+    const defaultCenter: [number, number] = [36.6486, 138.1948];
+    const [path, setPath] = useState<[number, number][]>([]);
+    const [midNodes, setMidNodes] = useState<[number, number][]>([]);
+    const [selectedIndex, setSelectedIndex] = useState<number>(0);
+    const [center, setCenter] = useState<[number, number]>(defaultCenter);
 
-    {/* ルート選択 */}
-    const handleSelectRoute = async (index: number) => {
+    const [error, setError] = useState<string | null>(null);
+
+    const getSelectRoute = useCallback(async (index: number) => {
         try {
+            setError(null);
             const res = await fetch(`${API_BASE}/select-route/${index}`);
             if (!res.ok) throw new Error('Network error');
             const routeData = await res.json();
-            console.log('取得したルート情報:', routeData);
+
+            const pathData = Array.isArray(routeData?.path) ? routeData.path : [];
+            const midData = Array.isArray(routeData?.mid_nodes) ? routeData.mid_nodes : [];
+
+            setPath(pathData);
+            setMidNodes(midData);
+            setSelectedIndex(index);
+            if (pathData.length > 0 && pathData[0] && pathData[0][0] != null && pathData[0][1] != null) {
+                setCenter(pathData[0]);
+            } else {
+                setCenter(defaultCenter); // fallback
+            }
+
+            console.log("取得したルート情報:", routeData);
         } catch (err) {
+            setError('ルートの取得に失敗しました');
             console.error('エラー:', err);
         }
-    };
+    }, []);
+
+    useEffect(() => {
+        if (numRoutes > 0) {
+            getSelectRoute(0);
+        } else {
+            setError('ルートの取得に失敗しました');
+            console.error('表示するルートがありません');
+        }
+    }, [numRoutes, getSelectRoute]);
 
     return (
         <div className="w-screen h-screen relative bg-gray-50">
+            {error && (
+                <div className="absolute top-2 left-1/2 -translate-x-1/2 bg-red-100 text-red-700 px-4 py-2 rounded shadow z-[2000]">
+                    {error}
+                </div>
+            )}
             {numRoutes > 0 && (
                 <div className="absolute top-4 left-4 z-[1000] space-x-2 bg-white p-2 rounded shadow">
                     {Array.from({ length: numRoutes }, (_, i) => (
-                    <button
-                        key={i}
-                        onClick={() => handleSelectRoute(i)}
-                        className="px-3 py-1 border rounded bg-blue-100 hover:bg-blue-300"
-                    >
-                        ルート{i + 1}
-                    </button>
+                        <button
+                            key={i}
+                            onClick={() => getSelectRoute(i)}
+                            aria-pressed={selectedIndex === i}
+                            className={`px-3 py-1 border rounded ${
+                                selectedIndex === i
+                                    ? 'bg-blue-500 text-white'
+                                    : 'bg-blue-100 hover:bg-blue-300'
+                            }`}
+                        >
+                            ルート{i + 1}
+                        </button>
                     ))}
                 </div>
             )}
             <MapContainer
-                center={centerPosition}
+                center={center}
                 zoom={16}
+                scrollWheelZoom={false}
                 className="w-full h-full"
                 style={{ minHeight: '100vh', minWidth: '100vw' }}
             >
+                {/* 中心を動かす宣言的コンポーネント */}
+                <ChangeMapCenter center={center} />
+
                 <TileLayer
                     attribution='&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
-                <Marker position={centerPosition} icon={defaultIcon}>
-                    <Popup>現在地！</Popup>
-                </Marker>
+
+                {center && center[0] != null && center[1] != null && (
+                    <Marker position={center} icon={defaultIcon}>
+                        <Popup>スタート地点</Popup>
+                    </Marker>
+                )}
+
+                {midNodes.filter(pos => pos && pos[0] != null && pos[1] != null).map((pos, i) => (
+                    <Marker key={i} position={pos} icon={defaultIcon}>
+                        <Popup>中間地点{i + 1}</Popup>
+                    </Marker>
+                ))}
+
+                {path.length > 1 && path.every(pos => pos && pos[0] != null && pos[1] != null) && (
+                    <Polyline positions={path} color="blue" />
+                )}
             </MapContainer>
         </div>
     );

--- a/frontend/src/pages/MapView.tsx
+++ b/frontend/src/pages/MapView.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
 import { useLocation } from 'react-router-dom';
 import L from 'leaflet';
@@ -22,15 +23,41 @@ const defaultIcon = L.icon({
     shadowSize: [41, 41],
 });
 
+const API_BASE = import.meta.env.VITE_API_BASE;
+
 const MapView: React.FC = () => {
     const location = useLocation();
-    const routeData = location.state?.routeData;
-    const path = routeData?.path || [];
-    const centerPosition = path[0];
+    const numRoutes = location.state?.numRoutes?.num_paths ?? 0;
+
+    const centerPosition: [number, number] = [36.6486, 138.1948];
+
+    {/* ルート選択 */}
+    const handleSelectRoute = async (index: number) => {
+        try {
+            const res = await fetch(`${API_BASE}/select-route/${index}`);
+            if (!res.ok) throw new Error('Network error');
+            const routeData = await res.json();
+            console.log('取得したルート情報:', routeData);
+        } catch (err) {
+            console.error('エラー:', err);
+        }
+    };
 
     return (
         <div className="w-screen h-screen relative bg-gray-50">
-            {/* 必要ならタイトルや戻るボタンをここに追加 */}
+            {numRoutes > 0 && (
+                <div className="absolute top-4 left-4 z-[1000] space-x-2 bg-white p-2 rounded shadow">
+                    {Array.from({ length: numRoutes }, (_, i) => (
+                    <button
+                        key={i}
+                        onClick={() => handleSelectRoute(i)}
+                        className="px-3 py-1 border rounded bg-blue-100 hover:bg-blue-300"
+                    >
+                        ルート{i + 1}
+                    </button>
+                    ))}
+                </div>
+            )}
             <MapContainer
                 center={centerPosition}
                 zoom={16}
@@ -44,9 +71,6 @@ const MapView: React.FC = () => {
                 <Marker position={centerPosition} icon={defaultIcon}>
                     <Popup>現在地！</Popup>
                 </Marker>
-                {path.length > 1 && (
-                    <Polyline positions={path} color="blue" />
-                )}
             </MapContainer>
         </div>
     );


### PR DESCRIPTION
## 概要
- バックエンドから送られてくる複数ルートを選択できるようにした
- ホームページの「例: 3」を「例: 2.5」に変更した

## やったこと
- MapView.tsx
- getSlectRouteという関数を作成し、ルート番号のapiを叩くことでルート情報を取得するようにしました。
- ルート取得できない際にアラートを表示するようにしました。
- 画面の中心を変更できるようにしました。（MapContainerのcenterは初回マウント時のみに反映されるため、setCenter()しても地図の中心は動かないため）
- Home.tsx
- 距離の入力例を3から2.5に変更しました。
- generate_routeのAPIを叩いた際のレスポンスを受け取る変数をnumRoutesに変更しました。
- api.py
- generate_route関数の返り値を生成されたルート数（num_paths）のみにしました。