### PR TITLE
[fix]tagグループの変更，プロンプトの変更

### DIFF
--- a/backend/app/tag_map.py
+++ b/backend/app/tag_map.py
@@ -1,40 +1,50 @@
-psychological_tag_map = {
+osm_tag_map = {
+    "calmness": [
+        {"tag": {"leisure": "park"}, "score": 10},
+        {"tag": {"natural": "wood"}, "score": 10},
+        {"tag": {"highway": "path"}, "score": 6},
+        {"tag": {"natural": "stream"}, "score": 7},
+        {"tag": {"highway": "primary"}, "score": -8},
+        {"tag": {"highway": "motorway"}, "score": -10},
+    ],
+    "recovery": [
+        {"tag": {"natural": "water"}, "score": 10},
+        {"tag": {"natural": "spring"}, "score": 9},
+        {"tag": {"amenity": "bench"}, "score": 8},
+        {"tag": {"leisure": "garden"}, "score": 8},
+        {"tag": {"highway": "steps"}, "score": -6},
+    ],
+    "safety": [
+        {"tag": {"lit": "yes"}, "score": 5},
+        {"tag": {"highway": "residential"}, "score": 6},
+        {"tag": {"barrier": "guard_rail"}, "score": 4},
+        {"tag": {"highway": "unclassified"}, "score": -6},
+        {"tag": {"natural": "cliff"}, "score": -10},
+    ],
+    "freedom": [
+        {"tag": {"tourism": "viewpoint"}, "score": 12},
+        {"tag": {"natural": "peak"}, "score": 10},
+        {"tag": {"leisure": "common"}, "score": 8},
+        {"tag": {"barrier": "fence"}, "score": -6},
+    ],
+    "exploration": [
+        {"tag": {"tourism": "attraction"}, "score": 8},
+        {"tag": {"historic": "ruins"}, "score": 9},
+        {"tag": {"artwork_type": "statue"}, "score": 6},
+        {"tag": {"highway": "path"}, "score": 5},
+        {"tag": {"barrier": "wall"}, "score": -5},
+    ],
+    "familiarity": [
+        {"tag": {"place": "neighbourhood"}, "score": 6},
+        {"tag": {"tourism": "information"}, "score": 5},
+        {"tag": {"route": "foot"}, "score": 5},
+        {"tag": {"highway": "motorway"}, "score": -10},
+    ],
     "nature_connection": [
         {"tag": {"natural": "wood"}, "score": 10},
         {"tag": {"natural": "tree"}, "score": 8},
         {"tag": {"leisure": "park"}, "score": 10},
-        {"tag": {"natural": "water"}, "score": 10},
-        {"tag": {"leisure": "garden"}, "score": 8}
-    ],
-    "openness": [
-        {"tag": {"tourism": "viewpoint"}, "score": 15},
-        {"tag": {"natural": "peak"}, "score": 12},
-        {"tag": {"natural": "cliff"}, "score": 10},
-        {"tag": {"landuse": "meadow"}, "score": 8}
-    ],
-    "safety_refuge": [
-        {"tag": {"lit": "yes"}, "score": 5},
-        {"tag": {"highway": "residential"}, "score": 5},
-        {"tag": {"amenity": "shelter"}, "score": 8},
-        {"tag": {"barrier": "guard_rail"}, "score": 5}
-    ],
-    "attention_restoration": [
-        {"tag": {"leisure": "picnic_site"}, "score": 10},
-        {"tag": {"amenity": "bench"}, "score": 8},
-        {"tag": {"amenity": "toilets"}, "score": 5},
-        {"tag": {"natural": "spring"}, "score": 8},
-        {"tag": {"leisure": "garden"}, "score": 8}
-    ],
-    "exploration_diversity": [
-        {"tag": {"tourism": "attraction"}, "score": 8},
-        {"tag": {"artwork_type": "statue"}, "score": 8},
-        {"tag": {"historic": "ruins"}, "score": 10},
-        {"tag": {"natural": "rock"}, "score": 6},
-        {"tag": {"highway": "path"}, "score": 5}
-    ],
-    "legibility": [
-        {"tag": {"tourism": "information"}, "score": 5},
-        {"tag": {"route": "foot"}, "score": 5},
-        {"tag": {"place": "neighbourhood"}, "score": 6}
+        {"tag": {"natural": "water"}, "score": 9},
+        {"tag": {"natural": "bare_rock"}, "score": -5},
     ]
 }

--- a/backend/debug.py
+++ b/backend/debug.py
@@ -10,7 +10,9 @@ if __name__ == "__main__":
     center_point = (35.681236, 139.767125)
     dist=1.5
     l = 0.3
-    user_input = "今日は静かで自然の多い場所を歩きたい"
+    user_input = """今日は朝から頭が重くて、人混みや騒音がすごくつらかった。
+少しでも静かで緑のある場所に行って、ゆっくり歩いて気分をリセットしたい。
+できればベンチに座って水の流れでも眺めたい。"""
     suggested_route,G = generate_routes(center_point[0],center_point[1],dist,l,user_input)
     for suggest in suggested_route:
         plot_path_on_graph(G,suggest["path_nodeids"])


### PR DESCRIPTION
## 内容
- 心理的要素を7項目定義して環境要素を明確に分離した
- 心理的要素に関連のある環境要素をPOIのtagとしてスコアとともにグルーピングした
- テキスト->心理的要素のようにLLMの目的を明確化した
- 散歩に対する潜在的なニーズを推論できるようにプロンプトの改善

## 心理的要素７項目
- calmness（落ち着き）: 騒がしい環境から離れ、静かに心を整えたい状態
- recovery（回復）: 肉体的・精神的な疲れから癒されたい状態
- safety（安心・安全）: 不安や緊張を避け、守られている感覚が欲しい状態
- freedom（開放感）: 圧迫感や閉塞感から解放され、自由を感じたい状態
- exploration（探索・刺激）: 退屈を避け、新鮮さや驚き、軽い冒険を求めている状態
- familiarity（親しみ）: 知っている場所や迷いにくい場所で安心したい状態
- nature_connection（自然とのつながり）: 緑や水、風など自然の要素と触れ合いたい気分