### PR TITLE
[feat]選択されたルートを保存する機能の実装（フロントエンド）

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -41,7 +41,7 @@ def parse_request(data: Dict[str, Any])-> Tuple[float, float, float, float, List
     entry_id = data.get("entry_id", "")
     return lat, lon, distance_km, lambda_score, categories, entry_id
 
-def build_response(suggested_routes: List[Dict[str,Any]]) -> Union[Response, Tuple[Response, int]]:
+def build_response(suggested_routes: List[Dict[str,Any]], entry_id) -> Union[Response, Tuple[Response, int]]:
     if not suggested_routes:
         return jsonify({"error": "ルートが見つかりませんでした"}), 404
     
@@ -49,7 +49,8 @@ def build_response(suggested_routes: List[Dict[str,Any]]) -> Union[Response, Tup
     distances = [result['total_km'] for result in suggested_routes]
     return jsonify({
         "num_paths": num_paths,
-        "distances": distances
+        "distances": distances,
+        "entry_id": entry_id
     })
 
 app.suggested_routes = []
@@ -58,8 +59,9 @@ def generate_route():
     logging.info("ルート生成リクエストを受け取りました")
     data = request.json
     lat, lon, distance_km, lambda_score , categories, entry_id= parse_request(data)
+    logging.info(entry_id)
     app.suggested_routes,_ = generate_routes(lat, lon, distance_km, lambda_score, categories)
-    return build_response(app.suggested_routes)
+    return build_response(app.suggested_routes, entry_id)
 
 @app.route('/select-route/<route_index>', methods=["GET"])
 def select_route(route_index):

--- a/backend/doc.md
+++ b/backend/doc.md
@@ -24,7 +24,8 @@ http://localhost:8000/
 ```json
 {
   "num_paths": 3,
-  "distances": [2.9, 3.1, 3.0]
+  "distances": [2.9, 3.1, 3.0],
+  "entry_id": "faagf123"
 }
 ```
 - 📍 /select-route/<index> (GET)

--- a/frontend/src/pages/NewDiaryComplete.tsx
+++ b/frontend/src/pages/NewDiaryComplete.tsx
@@ -43,7 +43,7 @@ const NewDiaryComplete: React.FC = () => {
                         lon,
                         distance: dist,
                         lambda_score: 0.3,
-                        id: id,
+                        entry_id: id,
                         categories: categories,
                     })
                 });
@@ -55,7 +55,8 @@ const NewDiaryComplete: React.FC = () => {
                     state: {
                         totalDatas : {
                             num_paths: result.num_paths,
-                            distances: result.distances
+                            distances: result.distances,
+                            entry_id: result.entry_id
                         }
                     }
                 });


### PR DESCRIPTION
## 概要
- マップ表示画面にて、「ルートを表示する」というボタンの追加
- ボタンを押した際に、ルート情報を保存するAPIを呼び出し、ルートを保存